### PR TITLE
feat: add ci test workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  test:
+    runs-on: self-hosted
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "14.2.0"
+      - name: package
+        run: xcodebuild test -scheme tkey_pkg -destination "platform=iOS Simulator,OS=16.2,name=iPhone 14" COMPILER_INDEX_STORE_ENABLE=NO

--- a/Package.swift
+++ b/Package.swift
@@ -9,18 +9,12 @@ let package = Package(
         .iOS(SupportedPlatform.IOSVersion.v15),
     ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "ThresholdKey",
             targets: ["tkey-pkg"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .binaryTarget(name: "libtkey",
                       path: "Sources/libtkey/libtkey.xcframework"
         ),


### PR DESCRIPTION
Requires a self-hosted runner as github does not yet provide hosted macos arm64 runners.